### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -413,6 +413,8 @@ jobs:
 
   # Test builds (smoke tests)
   test-builds:
+    permissions:
+      contents: read
     needs: [build-linux, build-windows, build-macos]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/matiaszanolli/Auralis/security/code-scanning/7](https://github.com/matiaszanolli/Auralis/security/code-scanning/7)

In general, fix this by explicitly specifying a `permissions` block either at the workflow root (applies to all jobs) or on each job, granting only the scopes required. For jobs that only read artifacts or repository contents and don’t interact with issues/PRs/releases, set `contents: read` and no write scopes. Jobs that need to create releases (like `create-release`) can retain `contents: write`.

For this workflow, we should add a `permissions` block to the `test-builds` job because CodeQL specifically flagged the job starting at line 415. The `test-builds` job downloads artifacts using `actions/download-artifact@v4` and performs filesystem checks; it does not need to modify repository contents, issues, or PRs. A minimal and safe configuration is:

```yaml
permissions:
  contents: read
```

We’ll insert this block under `test-builds:` and above `needs:` in `.github/workflows/build-release.yml`. No other code or jobs need to be modified, as `create-release` already has an explicit `permissions` block and other jobs don’t appear in the provided snippet as needing write access or being specifically flagged here.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
