### PR TITLE
test: Improve TrackList test infrastructure

### DIFF
--- a/auralis-web/frontend/src/components/library/__tests__/TrackList.test.tsx
+++ b/auralis-web/frontend/src/components/library/__tests__/TrackList.test.tsx
@@ -13,8 +13,8 @@
  * @module components/library/__tests__/TrackList.test
  */
 
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
-import { vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, within, cleanup } from '@/test/test-utils';
+import { vi, afterEach } from 'vitest';
 import TrackList from '@/components/library/TrackList';
 import { useTracksQuery } from '@/hooks/library/useLibraryQuery';
 import type { Track } from '@/types/domain';
@@ -62,6 +62,10 @@ const mockTrack3: Track = {
 describe('TrackList', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   describe('rendering', () => {


### PR DESCRIPTION
- Import render from @/test/test-utils instead of @testing-library/react
- Add proper cleanup() in afterEach hook
- Ensures all providers (Router, Theme, WebSocket, etc.) are available

Note: React 18 "Should not already be working" concurrency error persists across multiple test files. This is a deeper test infrastructure issue that needs investigation of:
  - Vitest/React 18 compatibility settings
  - Provider setup in test-utils
  - IS_REACT_ACT_ENVIRONMENT global flag

The auto-issue creation system will help track these failures systematically.