### PR TITLE
test: Fix CozyLibraryView mock setup for vi.mocked()

### DIFF
--- a/auralis-web/frontend/src/components/__tests__/CozyLibraryView.test.tsx
+++ b/auralis-web/frontend/src/components/__tests__/CozyLibraryView.test.tsx
@@ -11,7 +11,6 @@
  */
 
 import { vi } from 'vitest';
-import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@/test/test-utils';
 import userEvent from '@testing-library/user-event';
 import CozyLibraryView from '../library/CozyLibraryView';
@@ -20,6 +19,23 @@ import { usePlayerAPI } from '@/hooks/player/usePlayerAPI';
 
 vi.mock('@/hooks/library/useLibraryWithStats');
 vi.mock('@/hooks/player/usePlayerAPI');
+vi.mock('@/contexts/WebSocketContext', () => ({
+  useWebSocketContext: () => ({
+    subscribe: vi.fn(() => vi.fn()),
+    unsubscribe: vi.fn(),
+    sendMessage: vi.fn(),
+    isConnected: true,
+  }),
+  WebSocketProvider: ({ children }: any) => children,
+}));
+vi.mock('@/hooks/fingerprint/useAlbumFingerprint', () => ({
+  useAlbumFingerprint: () => ({
+    data: null,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
 vi.mock('../library/AlbumCharacterPane', () => ({
   AlbumCharacterPane: function MockAlbumCharacterPane() {
     return <div data-testid="album-character-pane">Album Character Pane</div>;


### PR DESCRIPTION
Resolves vi.mocked(...).mockReturnValue is not a function error by:
- Adding WebSocketContext mock to prevent reconnection loops
- Adding useAlbumFingerprint mock for React Query dependency
- Removing unused React import

The original TypeError was caused by missing context mocks that triggered async operations during tests. Component now renders successfully though tests need updating to match refactored component structure.