### PR TITLE
test: Add WebSocketContext mock to QueueManager tests

### DIFF
--- a/auralis-web/frontend/src/components/shared/__tests__/QueueManager.test.tsx
+++ b/auralis-web/frontend/src/components/shared/__tests__/QueueManager.test.tsx
@@ -31,6 +31,17 @@ import {
   mockTracks,
 } from './test-utils';
 
+// Mock WebSocketContext to prevent connection attempts
+vi.mock('@/contexts/WebSocketContext', () => ({
+  useWebSocketContext: () => ({
+    subscribe: vi.fn(() => vi.fn()),
+    unsubscribe: vi.fn(),
+    sendMessage: vi.fn(),
+    isConnected: true,
+  }),
+  WebSocketProvider: ({ children }: any) => children,
+}));
+
 // Mock the hooks
 vi.mock('@/hooks/websocket/useWebSocketProtocol', () => ({
   useQueueCommands: vi.fn(),


### PR DESCRIPTION
Adds WebSocketContext mock to prevent connection attempts during tests. This partially addresses the React concurrent mode cleanup errors, though all 29 tests still fail with "Should not already be working" during cleanup.

This is part of a systemic test infrastructure issue affecting multiple test suites (Integration, QueueManager, etc.) where React's concurrent mode scheduler detects conflicting work during component unmount.

Related to cleanup errors in:
- Integration tests (22/40 passing)
- QueueManager tests (0/29 passing currently)

The root cause appears to be async operations (WebSocket subscriptions, effects with timers) that aren't fully mocked or cleaned up before React attempts to unmount components.