### PR TITLE
Potential fix for code scanning alert no. 8: Uncontrolled command line

### DIFF
--- a/auralis/io/loaders/ffmpeg_loader.py
+++ b/auralis/io/loaders/ffmpeg_loader.py
@@ -42,6 +42,15 @@ def load_with_ffmpeg(file_path: Path, temp_folder: Optional[str] = None) -> Tupl
     if not check_ffmpeg():
         raise ModuleError(f"{Code.ERROR_FFMPEG_NOT_FOUND}: FFmpeg required for {file_path.suffix}")
 
+    # Ensure the input path is a regular file and not a URL/protocol
+    file_path = Path(file_path)
+    if not file_path.exists() or not file_path.is_file():
+        raise ModuleError(f"{Code.ERROR_FILE_NOT_FOUND}: {file_path}")
+    # Basic guard against ffmpeg protocol URLs (e.g., http://, pipe:, etc.)
+    file_path_str = str(file_path)
+    if "://" in file_path_str:
+        raise ModuleError(f"{Code.ERROR_UNSUPPORTED_FORMAT}: URL/protocol inputs are not allowed ({file_path_str})")
+
     # Create temporary WAV file
     if temp_folder:
         temp_dir = Path(temp_folder)
@@ -57,7 +66,7 @@ def load_with_ffmpeg(file_path: Path, temp_folder: Optional[str] = None) -> Tupl
 
         ffmpeg_cmd = [
             'ffmpeg',
-            '-i', str(file_path),
+            '-i', file_path_str,
             '-acodec', 'pcm_s16le',  # 16-bit PCM
             '-ar', '44100',          # 44.1 kHz
             '-ac', '2',              # Stereo


### PR DESCRIPTION
Potential fix for [https://github.com/matiaszanolli/Auralis/security/code-scanning/8](https://github.com/matiaszanolli/Auralis/security/code-scanning/8)

General approach: Ensure that any user-derived path reaching `ffmpeg` is (a) treated strictly as a file path, (b) constrained to a safe directory, and (c) not allowed to be some special protocol or non-file URL. Since we cannot change the router’s interface, we harden the place where the external command is actually invoked (`load_with_ffmpeg`) by validating that `file_path` is a regular file on disk and not a URL or unsafe pattern.

Best concrete fix with minimal behavior change:

- In `auralis/io/loaders/ffmpeg_loader.py`, inside `load_with_ffmpeg`, perform strict validation of the `file_path` argument before building `ffmpeg_cmd`:
  - Ensure `file_path` is a `Path` pointing to an existing file (`is_file()`).
  - Optionally reject path strings that look like URLs/protocols (`"://"` in the string) to avoid `ffmpeg`’s protocol-handling from being abused via query parameters.
- If validation fails, raise `ModuleError` with an appropriate error code instead of invoking `ffmpeg`.
- This keeps the external command invocation using a fixed argument list and adds an extra safety net regardless of how upstream code validated the path.

Concretely:

- Modify `load_with_ffmpeg` in `auralis/io/loaders/ffmpeg_loader.py`:
  - Immediately after checking `check_ffmpeg()`, add checks for `file_path.exists()`/`is_file()` and a simple filter against URL-like strings.
  - Log or raise using existing `ModuleError` and `Code` constants (re-using `ERROR_FILE_NOT_FOUND` is consistent with `load_audio`’s semantics).

No changes are needed in `enhancement.py`, `chunked_processor.py`, or `unified_loader.py` for this particular issue.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
