### PR TITLE
fix: VolumeControl test aria-label expectations for keyboard shortcuts

### DIFF
--- a/auralis-web/frontend/src/components/player/__tests__/VolumeControl.test.tsx
+++ b/auralis-web/frontend/src/components/player/__tests__/VolumeControl.test.tsx
@@ -197,8 +197,8 @@ describe('VolumeControl', () => {
       );
 
       const button = screen.getByTestId('volume-control-mute');
-      expect(button).toHaveAttribute('aria-label', 'Unmute');
-      expect(button).toHaveAttribute('title', 'Unmute');
+      expect(button).toHaveAttribute('aria-label', 'Unmute (⌨ M )');
+      expect(button).toHaveAttribute('title', 'Unmute (⌨ M )');
     });
 
     it('should display "Mute" label when not muted', () => {
@@ -212,8 +212,8 @@ describe('VolumeControl', () => {
       );
 
       const button = screen.getByTestId('volume-control-mute');
-      expect(button).toHaveAttribute('aria-label', 'Mute');
-      expect(button).toHaveAttribute('title', 'Mute');
+      expect(button).toHaveAttribute('aria-label', 'Mute (⌨ M )');
+      expect(button).toHaveAttribute('title', 'Mute (⌨ M )');
     });
   });
 


### PR DESCRIPTION
Updated test expectations to match component's keyboard shortcut enhancements:
- Mute button now shows 'Mute (⌨ M )' instead of just 'Mute'
- Unmute button now shows 'Unmute (⌨ M )' instead of just 'Unmute'

This is an accessibility improvement showing keyboard shortcuts in labels.

All 31 VolumeControl tests now passing.

Fixes #171