### PR TITLE
Potential fix for code scanning alert no. 20: Insecure randomness

### DIFF
--- a/auralis-web/frontend/src/services/AnalysisExportService.ts
+++ b/auralis-web/frontend/src/services/AnalysisExportService.ts
@@ -152,9 +152,29 @@ export class AnalysisExportService {
     this.startNewSession();
   }
 
+  /**
+   * Generate a cryptographically secure random base36 string segment.
+   */
+  private generateSecureIdSegment(length: number): string {
+    const chars = '0123456789abcdefghijklmnopqrstuvwxyz';
+    const segment: string[] = [];
+
+    // Use the Web Crypto API for cryptographically secure randomness
+    const cryptoObj = (window.crypto || (window as any).msCrypto);
+    const randomValues = new Uint32Array(length);
+    cryptoObj.getRandomValues(randomValues);
+
+    for (let i = 0; i < length; i++) {
+      const index = randomValues[i] % chars.length;
+      segment.push(chars.charAt(index));
+    }
+
+    return segment.join('');
+  }
+
   // Session Management
   startNewSession(metadata?: Partial<ExportMetadata>): string {
-    const sessionId = `auralis_session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    const sessionId = `auralis_session_${Date.now()}_${this.generateSecureIdSegment(9)}`;
 
     this.currentSession = {
       sessionId,


### PR DESCRIPTION
Potential fix for [https://github.com/matiaszanolli/Auralis/security/code-scanning/20](https://github.com/matiaszanolli/Auralis/security/code-scanning/20)

In general, to fix insecure randomness you should replace `Math.random()` when generating any value that might be used as a session identifier, token, key, password, or other security-sensitive value with a cryptographically secure random generator. In browsers, that means `crypto.getRandomValues`; in Node, `crypto.randomBytes`. For string IDs, it’s common to generate random bytes and then encode them (e.g., base36/hex) without significantly biasing the distribution in any exploitable way.

For this specific case in `AnalysisExportService.startNewSession`, we should replace the `Math.random().toString(36).substr(2, 9)` portion with a helper that uses `crypto.getRandomValues` (or `window.crypto.getRandomValues`) to generate a random alphanumeric string of the same length. To keep functionality unchanged, we will:  
- Add a small private method `generateSecureIdSegment(length: number): string` in `AnalysisExportService` that uses `crypto.getRandomValues` on a `Uint32Array` and maps the resulting values into the characters `0-9a-z`, building a base36-like string of the requested length.  
- Update the `startNewSession` method to call this helper instead of `Math.random().toString(36)...`.  
No additional imports are required because `crypto`/`window.crypto` is available in modern browsers’ global scope, and this is frontend code (`auralis-web/frontend/...`).

Concretely:
- In `auralis-web/frontend/src/services/AnalysisExportService.ts`, inside `AnalysisExportService`, add the private helper method near the top of the class (just after the constructor, for clarity).
- Change line 157 so that `sessionId` is constructed with `` `auralis_session_${Date.now()}_${this.generateSecureIdSegment(9)}` `` instead of the `Math.random()` expression.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
