### PR TITLE
fix: use useId() for stable gradient id to prevent DOM leak

### DIFF
--- a/auralis-web/frontend/src/components/shared/ui/loaders/LoadingSpinner.tsx
+++ b/auralis-web/frontend/src/components/shared/ui/loaders/LoadingSpinner.tsx
@@ -2,6 +2,7 @@
 import { Box, styled } from '@mui/material';
 import { rotate, pulse } from '@/components/library/Styles/Animation.styles';
 import { tokens, CircularProgress } from '@/design-system';
+import { useId } from 'react';
 
 interface LoadingSpinnerProps {
   size?: number;
@@ -35,7 +36,8 @@ export const LoadingSpinner = ({
   gradient: _gradient = tokens.gradients.aurora,
   className,
 }: LoadingSpinnerProps) => {
-  const gradientId = `gradient-${Math.random().toString(36).substr(2, 9)}`;
+  const uid = useId();
+  const gradientId = `gradient-${uid}`;
 
   return (
     <SpinnerContainer className={className} role="status" aria-label="Loading">


### PR DESCRIPTION
Closes #4190

### Summary
Replaced `Math.random()` with React 18's `useId()` for generating `gradientId` in `LoadingSpinner`. 

### Impact
This prevents the spinner from generating a new `<linearGradient>` on every render, which previously orphaned old gradient IDs in `<defs>`, causing a DOM leak (O(N) nodes) in long sessions and frequent re-renders.